### PR TITLE
Fix site SEO issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 locale                   : "en-US"
 title                    : "Dude, where's my Kaizen?"
 tagline                  : "Field notes on agentic engineering · Hamburg · MMXXVI"
+seo_tagline              : "Agentic Engineering"
 description              : "Field notes on agentic engineering by Björn Rochel — independent coach, working with teams from Hamburg."
 url                      : "https://bjro.de"
 baseurl                  :

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,11 +1,51 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+{% assign seo_title = page.title | default: site.title | strip_html %}
+{% assign seo_description = page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160 %}
+{% assign seo_url = page.url | absolute_url %}
+{% assign seo_image = page.image | default: site.og_image | absolute_url %}
 <title>{% if page.title %}{{ page.title | strip_html }} — {{ site.title | strip_html }}{% else %}{{ site.title | strip_html }} — {{ site.tagline }}{% endif %}</title>
-{% if page.excerpt %}<meta name="description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}" />{% else %}<meta name="description" content="{{ site.description }}" />{% endif %}
-<link rel="canonical" href="{{ page.url | absolute_url }}" />
+<meta name="description" content="{{ seo_description | escape }}" />
+<link rel="canonical" href="{{ seo_url }}" />
+{% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification }}" />{% endif %}
+<meta property="og:locale" content="{{ site.locale | replace: '-', '_' }}" />
+<meta property="og:type" content="{% if page.date %}article{% else %}website{% endif %}" />
+<meta property="og:site_name" content="{{ site.title | escape }}" />
+<meta property="og:title" content="{{ seo_title | escape }}" />
+<meta property="og:description" content="{{ seo_description | escape }}" />
+<meta property="og:url" content="{{ seo_url }}" />
+<meta property="og:image" content="{{ seo_image }}" />
+<meta property="og:image:alt" content="{{ page.image_alt | default: site.author.name | escape }}" />
+{% if page.date %}<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />{% endif %}
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="{{ seo_title | escape }}" />
+<meta name="twitter:description" content="{{ seo_description | escape }}" />
+<meta name="twitter:image" content="{{ seo_image }}" />
+<meta name="twitter:image:alt" content="{{ page.image_alt | default: site.author.name | escape }}" />
 <link rel="alternate" type="application/atom+xml" title="{{ site.title | strip_html }}" href="{{ '/feed.xml' | absolute_url }}" />
 <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon.svg' | relative_url }}" />
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 {% feed_meta %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "{% if page.date %}BlogPosting{% elsif page.url == '/' %}WebSite{% else %}WebPage{% endif %}",
+  "name": {{ seo_title | jsonify }},
+  "headline": {{ seo_title | jsonify }},
+  "description": {{ seo_description | jsonify }},
+  "url": {{ seo_url | jsonify }},
+  "image": {{ seo_image | jsonify }},
+  {% if page.date %}
+  "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+  "dateModified": {{ page.last_modified_at | default: page.date | date_to_xmlschema | jsonify }},
+  {% endif %}
+  "author": {
+    "@type": "Person",
+    "name": {{ site.author.name | jsonify }},
+    "url": {{ site.url | jsonify }},
+    "sameAs": {{ site.social.links | jsonify }}
+  }
+}
+</script>
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,7 +23,6 @@
 <meta name="twitter:description" content="{{ seo_description | escape }}" />
 <meta name="twitter:image" content="{{ seo_image }}" />
 <meta name="twitter:image:alt" content="{{ page.image_alt | default: site.author.name | escape }}" />
-<link rel="alternate" type="application/atom+xml" title="{{ site.title | strip_html }}" href="{{ '/feed.xml' | absolute_url }}" />
 <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon.svg' | relative_url }}" />
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 {% feed_meta %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,8 @@
 {% assign seo_description = page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160 %}
 {% assign seo_url = page.url | absolute_url %}
 {% assign seo_image = page.image | default: site.og_image | absolute_url %}
-<title>{% if page.title %}{{ page.title | strip_html }} — {{ site.title | strip_html }}{% else %}{{ site.title | strip_html }} — {{ site.tagline }}{% endif %}</title>
+{% assign document_title = page.seo_title | default: page.title | strip_html %}
+<title>{% if page.title %}{{ document_title }} — {{ site.author.name }}{% else %}{{ site.title | strip_html }} — {{ site.seo_tagline }}{% endif %}</title>
 <meta name="description" content="{{ seo_description | escape }}" />
 <link rel="canonical" href="{{ seo_url }}" />
 {% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification }}" />{% endif %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,7 +1,11 @@
 <header class="masthead">
   <div class="eyebrow">{{ site.tagline }}</div>
   <div class="masthead-row">
+    {% if page.url == '/' %}
     <h1><a href="{{ '/' | relative_url }}">Dude, where&rsquo;s my <span class="roman">Kaizen</span>?</a></h1>
+    {% else %}
+    <div class="site-title"><a href="{{ '/' | relative_url }}">Dude, where&rsquo;s my <span class="roman">Kaizen</span>?</a></div>
+    {% endif %}
     <nav class="nav">
       {% assign section = page.nav_section | default: page.layout %}
       <a href="{{ '/' | relative_url }}"{% if section == 'home' or page.url == '/' %} class="active"{% endif %}>Writing</a>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -23,7 +23,7 @@ nav_section: archive
     {% assign now_year = 'now' | date: '%Y' | plus: 0 %}
     {% assign span = now_year | minus: first_year | plus: 1 %}
     <div class="archive-stats">{{ total }} Dispatches · {{ span }} Years · ≈{{ hours }} hrs of reading</div>
-    <h2>{{ page.title | default: "The Archive — every dispatch since 2014." }}</h2>
+    <h1>{{ page.title | default: "The Archive — every dispatch since 2014." }}</h1>
 
     {% for yr in by_year %}
     <section class="year-section" id="y-{{ yr.name }}">

--- a/_pages/archive.html
+++ b/_pages/archive.html
@@ -1,6 +1,7 @@
 ---
 layout: archive
 title: "The Archive — every dispatch since 2014."
+excerpt: "Browse Björn Rochel's writing on agentic engineering, software architecture, GraphQL, and engineering leadership."
 permalink: /archive/
 nav_section: archive
 ---

--- a/_pages/now.html
+++ b/_pages/now.html
@@ -9,7 +9,7 @@ nav_section: now
 
   <main>
     <div class="now-meta"><span class="dot"></span> Now · a /now page · last updated {{ site.now.updated | default: "July 11, 2026" }}</div>
-    <h2>What I&rsquo;m working on, right this quarter.</h2>
+    <h1>What I&rsquo;m working on, right this quarter.</h1>
     <p class="preface">Inspired by Derek Sivers&rsquo; <a href="https://nownownow.com/about">/now</a> convention. A standing answer to &ldquo;what are you up to these days?&rdquo;</p>
     <hr class="thin" />
 

--- a/_pages/now.html
+++ b/_pages/now.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Now"
+excerpt: "What Björn Rochel is working on now: agentic engineering coaching, training, writing, and software-factory tools."
 permalink: /now/
 nav_section: now
 ---

--- a/_posts/2018-10-21-per-aspera-ad-astra.md
+++ b/_posts/2018-10-21-per-aspera-ad-astra.md
@@ -32,7 +32,7 @@ I hope you folks enjoy the ride as much as I did!
 Best,
 Björn
 
-# Table of Contents
+## Table of Contents
 1. [What made us interested in GraphQL](/what-made-us-interested-in-graphql/)
 2. [Kickstarting the project](/kickstarting-the-project/)
 3. [Choosing the right technology](/choosing-the-right-technology/)

--- a/_posts/2018-10-21-per-aspera-ad-astra.md
+++ b/_posts/2018-10-21-per-aspera-ad-astra.md
@@ -1,4 +1,5 @@
 ---
+title: "Per Aspera Ad Astra"
 excerpt: "Series intro: how four people set out to introduce GraphQL at XING, and the playbook for landing platform-shift technology inside a 1.3k-person company."
 ---
 Since 2013 I've just written a single blog post on my [original blog](http://www.bjro.de). It's

--- a/_posts/2018-10-25-what-made-us-interested-in-graphql.md
+++ b/_posts/2018-10-25-what-made-us-interested-in-graphql.md
@@ -1,4 +1,5 @@
 ---
+title: "What Made Us Interested in GraphQL"
 excerpt: "Four years of API pain at XING — the field-selection hacks, the REST-vs-mobile tug-of-war, and the moment GraphQL stopped feeling theoretical."
 ---
 When I try to trace back why I think `GraphQL` is a good fit for us, I always end up somewhere in the years 2012, 2014 and 2016. Apologies upfront, this is going to be a long one.

--- a/_posts/2018-10-25-what-made-us-interested-in-graphql.md
+++ b/_posts/2018-10-25-what-made-us-interested-in-graphql.md
@@ -3,7 +3,7 @@ excerpt: "Four years of API pain at XING — the field-selection hacks, the REST
 ---
 When I try to trace back why I think `GraphQL` is a good fit for us, I always end up somewhere in the years 2012, 2014 and 2016. Apologies upfront, this is going to be a long one.
 
-# 2012
+## 2012
 In 2012 I started working for `XING` in the API - team. Together we launched `XINGs` public `REST` API that same year. The infrastructure for that had already been in place for roughly two years (I think) and was also the data source for `XINGs` own native mobile applications. In fact many of the APIs that you would find later in the public `REST` API originated in the context of those applications and at least for a short time there was a 100% overlap between the public API and what the mobile apps were using. 
 
 One thing we already had at that time was a query parameter called `fields` on the users API and `user_fields` on every API that was referencing users. These query parameters expected a comma separated list of field names and if you would call the API that way, you'd only get back what you had requested. It even supported nesting so you could request `business_address.city` to only get the city portion of the business address. If you look at it now from a `GraphQL` perspective, you might think "wait a minute, that sounds almost like a mini selection set" and I think this isn't too far off. It had the same benefits (tracking, e.g. who is using what and bandwidth optimization, e.g. only transfer what the client actually needs) but obviously ours was a very simple, poor mans version of the idea.
@@ -36,7 +36,7 @@ Remember part of the teams mission statement was to make the APIs as easy and se
 
 Ultimately this experience made me realize that whatever solution might appear in the future that would improve the API game for mobile applications, it would be one with a very good developer experience and strong, multi platform tooling support.
 
-# 2014
+## 2014
 Between 2012 and 2014 something interesting happened somewhere else inside `XING`. When I started in the company in 2012, the majority of the developers was still working in one of two monolithic applications. One being written in `Perl` (the original `OpenBC`) and another one in `Ruby on Rails` (containing all recent developments). The API infrastructure was part of the big `Ruby on Rails` application. Overall it kinda looked like this (I'm obviously omitting some details here for simplicity):
 
 {% include figure image_path="/assets/images/xing-2012.png" %}
@@ -67,7 +67,7 @@ The list can probably go further. The jump into this kind of architecture is not
 
 > It makes me even more chuckle seeing some people on the internet advocating micro-service architecture (that shares similar traits) to small teams when starting their app. Good luck my friends, good luck.
 
-# 2016
+## 2016
 During 2016 more interesting stuff happened. The quick fixes outlined above allowed us to parallelize our API development and with that our mobile development quite a bit. And we grew as an organization a lot. And when I say a lot, I mean it. Just look at the following picture.
 
 {% include figure image_path="/assets/images/xing-growth.png" %}
@@ -78,7 +78,7 @@ Also `React` became a thing (pushed by our colleagues from the Frontend Architec
 
 These two things in combination were the last drops that were necessary to convince us that we needed to do something more radical about the API topic and a new project was started. This eventually became `XING One`, the project and `XING One` the application which I want to talk about in more detail in this series.
 
-# Our requirements
+## Our requirements
 This was probably the longest prologue I've ever written for a blog post. I hope I didn't lose you on the way. What I hopefully managed to convey is the steps and missteps we made with our API and what impact it had on the organization as a whole as it grew. 
 
 When we were gathering requirements for our new project, one thing became very clear: We wanted the new solution to have the good properties of our previous ones, while having less of their downsides. 
@@ -100,7 +100,7 @@ The picture that was forming in our head as a goal looked like this:
 
 {% include figure image_path="/assets/images/xing-one-idea.png" %}
 
-# So why GraphQL?
+## So why GraphQL?
 I still remember the first wave of `GraphQL` talks that were coming out in 2015. They weren't showing much code at the time, but I remember thinking: "Jeeez, this might be it", "Hey that almost sounds like they had similar problems" or "I bet this could develop into something that might be super helpful to fix our API issues".
 
 If you go through the desired characteristics, some obviously needed some creativity from us, but others were already solved by how `GraphQL` was conceptually working.

--- a/_posts/2018-10-31-kickstarting-the-project.md
+++ b/_posts/2018-10-31-kickstarting-the-project.md
@@ -19,7 +19,7 @@ and probably many many more.
 
 I always viewed this project as a golden opportunity to do something truly great on our platform. To right some past wrongs. To enable the platform to take a productivity leap where previously tiny steps where the norm. That's why I didn't want to go naive into the project and tried to go some extra miles, that hopefully would accumulate and contribute to the success of the project.
 
-# Setting the initial tone
+## Setting the initial tone
 My boss at the time had already made up his mind about the project name. He wanted to call the project `Everest`, because another project to establish a PAAS via Kubernetes named `Olympus` had been started earlier. I hated that name from the moment I heard it. Especially given that people have died trying to ascend that mountain. And also, to be frank, because I already had a name for this in mind: `XING One`. Luckily I managed to convince him that this one would be a better choice.
 
 Most of the people at my current company know the name, but only very few know where the name originated. Some colleagues think it comes from "Lord of the Rings" (ala the one API to rule them all), but this isn't the case. It's a nod to the book [American Icon](https://www.goodreads.com/book/show/13132620-american-icon) which recounts the story of how Allan Mulally managed save and turn around the Ford Motor Company during the early 2000s. It's a remarkable story of what an aligned team with a shared goal and a clear mission can achieve. Mulallys misson statement for their turnaround strategy was "One team, One plan, One Goal".
@@ -36,7 +36,7 @@ I loved that. It's simple, memorable and uniting. With that it sets the initial 
 >
 >* __One Community__ - Evolve and scale API work via a Community of Practice  
 
-# Aligning other major stakeholders
+## Aligning other major stakeholders
 But this wasn't it. There were still some things that I wanted to get done, before diving into the technical details. One thing on the list was aligning with the major non-technical stakeholders in the company. In this case it was mostly the higher level management of the mobile product organization.
 
 > You might wonder why I consider our product colleagues largely as non-technical. It's a completely valid question, but the answer to that is a whole story for itself. For the moment think of engineering and product management at XING as two different groups, with the usual communication and collaboration challenges that arise from that.
@@ -55,7 +55,7 @@ In the meantime, my boss time did manage to convince one product engineering tea
 >
 >This rift is going to be something I'll separately write about in a future post. __So I leave it at that here with the hindsight that I'd probably approach that portion differently if I had to do it again with all I know today.__
 
-# How do we actually start this?
+## How do we actually start this?
 Great, so the alignment part was kinda covered. I knew what I wanted to do. But I didn't yet know in what technology stack we later would implement `XING One` in. To be honest at the time I also had only vague ideas in how we would approach selecting the target solution. The team wasn't formed yet, it was still just me (Alexis the 2nd member of the team started roughly 3 weeks later). But I had a wild idea: Turning the assumptions I had about `GraphQL` into a checklist, implementing prototype versions of `XING One` in all the candidate technology stacks and then doing a shootout between them. 
 
 How exactly I approached this is a topic for the next entry in the series. Hope you enjoyed this. See you next time around!!!

--- a/_posts/2018-11-16-the-game-plan.md
+++ b/_posts/2018-11-16-the-game-plan.md
@@ -34,14 +34,14 @@ Track one would develop the infrastructure and track two would develop the first
 
 The initial plan was to remove `graphql-ruby` out of the equation in July 2017 and to connect the `GraphQL` infrastructure to the product backend via `HTTP` / `JSON` APIs.
 
-# The MVP and later versions
+## The MVP and later versions
 As I already pointed out in one of the earlier posts, we wanted to deliver value as early as possible and at the same time had a larger idea around how the developer experience around the `GraphQL` infrastructure should be. Our lofty goal for the infrastructure was that it should not require any knowledge of `Scala` in order to work with it, but instead use [GraphQL SDL](https://www.prisma.io/blog/graphql-sdl-schema-definition-language-6755bcb9ce51/) together with some custom directives to define the schema. 
 
 That's obviously a lot to figure out and to bring to a production ready state in that timeframe (especially if you didn't yet know `Scala` that well). Because of that we decided to first focus on an intermediate version that didn't use `SDL`, but was using `Scala` to define the schema. That was the version we were shooting for until July 2017. Somewhere in autumn we would then try to figure out how we could marry the `Scala` schema with the `SDL` schema. 
  
 >The idea being the "marrying" was that it would give us a lot flexibility if we could always drop back to `Scala` when we ran into limits with `SDL` or when there was simply functionality that we wanted to have in the schema but that was to complex to be generically expressed via `SDL`. An idea that turned out to be tremendously useful in the end.
 
-# Boundaries for the infrastructure
+## Boundaries for the infrastructure
 One thing we also tried to make as early as possible transparent to the rest of the organization was how we would structure the integration with the underlying APIs and what the implications of our approach would be for our product teams (both technically and organizationally). 
  
 > With "early" I mean this: When I gave the first presentation __0 lines of code__ were written. For the second presentation probably didn't have more than __15%__ of the MVP ready. Nevertheless I think managing assumptions and expectations around a project is crucial for its success. So the remainder of this post is about those other early pillars.
@@ -103,7 +103,7 @@ You'd get back a `JSON` object which has at minimum a `collection` field that co
 
 That's actually good enough to handle the typical scenario of "load list x from here and for each item load something else from there" for a lot of the cases.
 
-# Some last words
+## Some last words
 Today I talked about how we approached building out our `GraphQL` to `REST` gateway from a very high level. I also talked about some of the rules and conventions about how the infrastructure would integrate with the internal APIs. 
 
 Next time around, I'll dive in one specific aspect in particular: What you can do in a software project of this size to maintain adaptiveness, e.g. the ability to make mistakes and being able to course correct with fairly low overhead and cost. 

--- a/_posts/2018-11-23-on-agile-codebases.md
+++ b/_posts/2018-11-23-on-agile-codebases.md
@@ -17,7 +17,7 @@ So, after bailing out on that, I would like to talk about something much simpler
 
 So let's have a look at those.
 
-# 1. Coding with the right mindset
+## 1. Coding with the right mindset
 You can go into a new software adventure with the "I'm going to rock this" attitude. Especially if you're coming from other successful stints or projects and are highly confident in your capabilities. 
 
 Or you can choose to be a bit more humble. 
@@ -37,7 +37,7 @@ and probably some more changes that I don't remember off the top of my head righ
 
 What I want to say is this: Even though our outside `GraphQL` server interface didn't change much over the course of the first year, the internals were constantly revised, rewritten and improved, on a system that after 6 month had already real production traffic and real users on it.
 
-# 2. Use an refactoring friendly language stack
+## 2. Use an refactoring friendly language stack
 I'm repeating myself here, but I want to emphasize the point. If you can't change your software fast and in a fairly cheap manner, you will have a hard time trying to work with agile and iterative product development. The ability to pull of refactoring with confidence, low ceremony and fairly low effort is key to a successful agile implementation. Move fast and break things sounds super sexy until you actually start breaking things and turn your users against your product. Your customers actually like when your application behaves predicatably. Your boss probably too .... and wait ... I guess you as well. So make sure that you can refactor with ease.
 
 There are different opinions on what makes a codebase easy to refactor out there. Dynamic typing advocates usually mention that you have less code to work with and less abstractions that you need to deal with, that it's faster because the compiler is usually slow. People from the static typing camp usually bring up the better tool support and that the compiler does a great job for you (whose absence you have to compensate in dynamic languages for instance by writing more tests).
@@ -50,17 +50,17 @@ Once a codebase has reached a certain size I can definitely see a lot for value 
 
 `Scala` for me with `Intellij` fits well into this category, but it's not without it's caveats.
 
-# 3. Throw out refactoring unfriendly language features
+## 3. Throw out refactoring unfriendly language features
 There is `"A better Java" - Scala` and there's `"I'd rather do Haskell but I'm stuck with this" - Scala`. The latter comes with one of the most refactoring unfriendly features I have actually seen in a static language, `implicts`. Not only do they slow down your IDE quite dramatically, they also cause puzzling looks on developers faces, when somebody removes an "import" by accident and the application doesn't compile anymore. 
 
 You certainly can do cool things with them (Typeclasses anyone?), but I don't think `implicts` are worth the cost. Especially when you know that you want to rely on refactoring capabilities a lot. 
 
-# 4. Remove unnecessary discussions about code style and conventions
+## 4. Remove unnecessary discussions about code style and conventions
 Debates about code style are lovely time-sinks and I'm super grateful for the development of the recent years that brought more and more tools into the various tech stacks that do automated code formatting, based on some agreed upon time conventions. I'm not sure where it originated, but I think [gofmt](https://golang.org/cmd/gofmt/) started this. I definitely appreciate the idea. Consequently we relied on [scalafmt](https://scalameta.org/scalafmt/) from day one and since that day it's automatically ensuring that all our contributions are in a similar format. 
 
 We also had fairly conservative [Scalastyle](http://www.scalastyle.org/) checks in place early on. `Scala` gives you many options on how to write your code (ranging from `obj.method()` to `obj function`). While I like the idea of the "scalable programming language", having multiple of those styles mixed together in one application, makes it more confusing to work with the code in a team and creates unnecessary distractions. Also here we favored the boring solution of `obj.method()` over the more functional syntax.
 
-# 5. In-memory integration tests yield the most bang for the buck 
+## 5. In-memory integration tests yield the most bang for the buck
 One thing that I've seen many teams struggle with that embraced automatic testing, is finding the right testing approach that brings not only safety, but also speed and confidence. Similar to agile, I think you can see quite a bit of cargo culting in the automated testing area. Don't get me wrong, automated tests are an essential part of everything I've done in the last years, but somehow more often than not, when I look into different teams codebases, the setup falls into one of two extremes:
 
 1. Heavy reliance on end-to-end integration tests, which are usually not very insightful, very slow, aren't run often and even worse sometimes even flaky (especially when you're dealing with distributed applications)
@@ -135,7 +135,7 @@ class ConstResolverSpec extends EngineSpecification {
     // Shortened
   }
 ```
-# 6. Get rid of cross repository coordination
+## 6. Get rid of cross repository coordination
 At my current company we favor very small repositories. Libraries have their own repository. Individual services have their own repository. It also often happens that integration tests are located in a different repository. That definitely has some advantages. You isolate the work from different people better, including having a clear, focused git commit history. You also don't spend a lot time cloning on that particular repository. You can pick only the few repositories that you need and then you're good (compared to cloning the world and then using just a small portion of it).
 
 But it also has a very clear disadvantage: Coordination. Say for instance your documentation is in one repository, your `GraphQL` server in another, integration tests are in a third repository and then maybe the client libraries are in a fourth one. Now things become slightly more complicated, because you can't change everything in a single pull request. You can't review all the changes that belong to each other as a whole. QA also becomes interesting since you now have to figure out how to temporary bring things together for validation (usually involving lots of branches). And last but not least, you now probably have an integration order. 
@@ -148,7 +148,7 @@ In our company it wasn't always a free lunch though. The small repository approa
 
 As I outlined earlier, I would do it again. Overall the benefits of the mono repository outweigh the costs for me.
 
-# Conclusion
+## Conclusion
 
 Today I ranted a bit about agile and then talked in more depth about some more technical decisions and tweaks we did that allowed us to iterate fast and with confidence. 
 

--- a/_posts/2018-11-4-choosing-the-right-technology.md
+++ b/_posts/2018-11-4-choosing-the-right-technology.md
@@ -14,7 +14,7 @@ I also felt that our project shouldn't be restricted by heritage and that we sho
 
 "Opinions", "doubts", let's be honest, we're all more or less biased one way or another. I definitely know I was biased when it came to certain technologies I had used before (at the time I was a heavy advocate for `Elixir` for example). But I thought it was a good idea to counter balance that bias through a more transparent and structured selection process.
 
-# Enter the Premortem
+## Enter the Premortem
 Some months prior, I had read [Decisive](https://www.goodreads.com/book/show/15798078-decisive) by Chip and Dan Heath and one of the tools that was described in there, was a `Premortem`. In a nutshell a `Premortem` is the hypothetical opposite of a `Postmortem`: You don't analyze the failure after the fact, but instead hypothesize what could turn the project into a spectacular failure and then ask the simple questions of *"Why?"* and *"What would I have done about it, if I had known earlier?"*. 
 
 Done collaboratively it allows you to surface risk and brainstorm detection and mitigation strategies from multiple viewpoints in the earlier phases of an initiative. Those phases when you can still do something about it. Of course this doesn't rule out `Black Swans`, the [unknown unknowns](https://de.wikipedia.org/wiki/There_are_known_knowns), but it certainly helps to form the right mindset: To be proactive, instead of reactive. Since it was only me back then, I mostly used my boss as the sparring partner for the `Premortem`, which also helped me to understand the project from a management perspective better. 
@@ -24,7 +24,7 @@ Done collaboratively it allows you to surface risk and brainstorm detection and 
 You don't need some sophisticated tech for this. Our first version was an `Excel` sheet that was later moved to `Confluence` for documentation purposes. To give you some general idea how this might look like, ours kinda looked like this (even though this is just an excerpt, the real one is multiple pages long):  
 {% include figure image_path="/assets/images/premortem.png" %}
 
-# The checklist
+## The checklist
 You probably know this famous quote from Yogi Berra: **"In theory there is no difference between theory and practice. In practice there is."**. During the `Premortem` phase we developed strong hunch that the technology decision for `XING One` needed to contain some decent amount of hands-on coding in the respective options. 
 
 Because of that we decided to do something that was unusual and uncommon for technology projects at `XING` (and to my knowledge still is): __We spend the first 1,5 months actually implementing a throwaway prototype of our idea in all the relevant technologies__
@@ -68,7 +68,7 @@ Please note that your looking at the summary overview. Internally a longer descr
 >
 >Please also note that we were doing this evaluation in __February 2017__. Work on `apollo-server` had just begun. Re-doing the evaluation today might result in a slightly different ranking. I doubt though, that the top spot for us would be different.
 
-# Why we chose Sangria
+## Why we chose Sangria
 In the end `Sangria`, the `Scala` solution, turned out to be our favorite. It collected many plus points during the prototyping phase:
 
 * The [documentation](https://sangria-graphql.org/learn/) was top-notch

--- a/_posts/2019-01-11-graphql-retro.md
+++ b/_posts/2019-01-11-graphql-retro.md
@@ -21,7 +21,7 @@ Some of the things that I'm going to reflect about today are likely the result o
 
 That being out of the way, let's dive into our learnings and observations:
 
-# 1. Expectations on GraphQL vary dramatically between web and native mobile developers
+## 1. Expectations on GraphQL vary dramatically between web and native mobile developers
 Have you ever called into a `GraphQL` service by hand, without some `GraphQL` specific tooling? Like with `curl` or `fetch`? If you've tried that and have understood the format that a `GraphQL` server expects, then you realize that everyone who is able to do a `REST` call is also able to interact with a `GraphQL` server. They are not too far apart. Sure, the error handling differs significantly, but the general mechanics of obtaining data a very close. 
 
 This enabled for us a more or less straight forward iterative rollout plan: 
@@ -47,14 +47,14 @@ The point to take away from this is that you should plan and setup your `GraphQL
 >
 > In case you wondering: In 2017 I sat next to [Dan Schaefer](https://twitter.com/dlschafer) in the cab on the way to the speakers dinner for the `GraphQL EU` conference and had the chance to pester him with all sorts of questions. Dan is one of the original `GraphQL` creators (besides [Nick Schrock](https://twitter.com/schrockn) and [Lee Byron](https://twitter.com/leeb)).
 
-# 2. Client libraries weren't on par when we started
+## 2. Client libraries weren't on par when we started
 I hinted it in the first point, if you're going to build not only for web but also for the native platforms, you have to be aware that there is quite a difference in breadth and depth of available documentation for those different platforms. When we started in early 2017 documentation for the native client libraries was basically not existent. The `Android` library was in a very early alpha state, the `iOS` version was a bit (but not much) ahead. 
 
 Both of our mobile teams looked at them in `2017` and eventually decided to roll their own tooling. This made the integration into our `OAuth 2.0` flow and the rest of the existing application easier, but obviously also comes with a cost associated. Many of cooler later additions on the client side libraries can't be found in our native mobile applications. 
 
 I guess it's one of the prices you often need to pay as an early adopter. Just looking at `Github` today, it looks like the libraries have nicely developed in the meantime. If faced with a similar choice today, the result would probably be different.
 
-# 3. All client developers struggled with error-handling and partial results
+## 3. All client developers struggled with error-handling and partial results
 In November `2017` I gave a talk about our `GraphQL` experience in Munich while visiting `Autoscout 24`. One thing that stuck with me from the following Q&A is that one of their Lead Engineers was noticeably taken aback by my assessment that client engineers struggle with error handling and partial responses more than expected. From his point of view the partial responses were one of the reasons to use `GraphQL` and he was heavily advocating that on their sided. And now I came along and talked about how our frontend colleagues struggle to make the shift there.
 
 The interesting thing here is that I don't even have a very different personal opinion. I think partial errors are great. That the server is able to give you something back in case he can't resolve all of the data is actually a great premise to me. Especially if your `GraphQL` server (like ours) is a gateway that is remotely talking to other services and the [fallacies of distributed computing](https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing) come into play. Partial results reflect the reality of a distributed platform much better than the normal binary "worked" or "didn't work" approach (when in the latter case maybe just a tiny portion of the data couldn't be resolved). 
@@ -63,7 +63,7 @@ But at least in our company I made the observation that frontend developers aren
 
 Things take a while to stick. Especially if you're coming from a `REST` setup and your work affects many people, I would try to clarify this aspect as one of the earlier topics.
 
-# 4. Even though GraphQL documentation is great, onboard carefully
+## 4. Even though GraphQL documentation is great, onboard carefully
 At the start of 2017, if you wanted to understand how `GraphQL` worked and what kind of assumptions it did, there were already great resources out there, especially [graphql.org](https://graphql.org/). We pointed the first team we worked with towards these resources. Needless to say, it turned out that this wasn't enough. Otherwise I wouldn't be writing about this now :)
 
 Great documentation is awesome, for the case where people actually bother to read it. At least half of the people you typically meet also do this. The other side immediately goes into exploration mode and tries to build something, without going into the documentation. And out of that group from my experience one half reads the documentation when it encounters problems. The other half doesn't even do that. That group usually approached us in frustration about why "this" and "that" wasn't working as they expected.
@@ -78,7 +78,7 @@ From this experience we changed our rollout scheme dramatically. We developed a 
 
 In one of the earlier parts of the series I talked about that we treated everything as an `MVP`: The implemented server, the process and the documentation. Onboarding was a logical addition to this and we continue to do these workshops even in 2019.
 
-# 5. GraphQL type system feels (sometimes) too basic
+## 5. GraphQL type system feels (sometimes) too basic
 When working with a large group of people on a schema, I think `GraphQL` is lacking some basic things in the schema. I think this is independent of whether you work with a single schema or use some form of schema-stitching. 
 
 The first one that comes to mind is the simple concept of `namespaces`. A "profile" in one domain might be something completely different to a "profile" in another domain. You might want to call both "profile". As of now, if you want to have both of them in a schema, you need to make their names unique, usually by prefixing their name somehow. For instance having a `CompanyProfile` and a `MemberProfile`. That's also what we do currently.
@@ -95,14 +95,14 @@ This shows the documentation of a field that is backed by a `REST` API, where mu
 
 But this is a duck-tape solution and again I would prefer to have a real answer similar to this for `GraphQL`. I think the logical solution for this would be to make server side directives part of the exposed schema, but I'm not aware of any plans to add this. 
 
-# 6. GraphQL spec lacks a pagination abstraction
+## 6. GraphQL spec lacks a pagination abstraction
 Sooner or later as an application developer you will encounter the topic of pagination in your schema. The `GraphQL` spec is completely agnostic when it comes to the pagination topic. 
 
 It's not like there isn't a fitting spec available. The [Relay Cursor Connection Specification](https://facebook.github.io/relay/graphql/connections.htm) pretty much exists since the early days of `GraphQL`, but separately from the `GraphQL` spec. Prominent `GraphQL` APIs like [Github](https://developer.github.com/v4/guides/intro-to-graphql/) and [Shopify](https://help.shopify.com/en/api/custom-storefronts/storefront-api/graphql) do make use of it. We also use it more and more (both for real cursors and as an adapter around `limit` and `offset` based APIs).
 
 Not having a default pagination abstraction obviously gives some flexibility and adaptability for `GraphQL` itself, but I can't help to think that `GraphQL` could benefit from having a default abstraction for this out of the box. If there was an explicit concept, tooling could make better use of this and also frontend components would have a more standardized notion of pages of data. 
 
-# 7. Don't be naive with file uploads
+## 7. Don't be naive with file uploads
 Somewhere in the middle of 2017 the topic of file uploads came up. We did the simplest possible solution: Tunneling the binary file as a `Base64` encoded blob though our `GraphQL` mutation. That works, but is in general a very bad idea. You could even call it naive.
 
 Take a look at the following dashboard. Guess where most of the `P999` and `MAX` numbers are coming from :-(
@@ -115,7 +115,7 @@ We're in the process of migrating away from this quick-fix to a separate upload 
 
 I can only advice you not repeat this mistake and keep uploads separately where possible.
 
-# 8. We struggled with our mutation design
+## 8. We struggled with our mutation design
 Oh mutations, another unexpected headache. You see `GraphQL` servers execute hierarchically and sub-selections only apply when the parent resolver was successful.
 
 The first version of mutations was pretty simple in that sense that for successful `REST` calls underneath, we expanded the selection and where they failed, we added an entry for them as error extensions into the global `errors` collection. Straight forward, or so we thought. 
@@ -140,7 +140,7 @@ On the other hand, we broke two basic things that are worth mentioning:
 
 We have some few noteworthy occurrences where for queries, the same team that heavily objected our first mutation design is now more or less perfectly fine with reading out of the `errors` collection in case a query failed. You only realize this in retrospect, but to me this indicates that we as an `API` team maybe gave in to early in order in this area of `GraphQL` to please our customers. 
 
-# 09. Retrofitting into an existing APM solution is easier than you think
+## 09. Retrofitting into an existing APM solution is easier than you think
 When the question comes up today how you would monitor performance and health of your `GraphQL` application, 
 you'll likely eventually end up with [Apollos toolsuite](https://www.apollographql.com/platform/). The company has done a good job capturing the momentum with their former `Apollo Engine` product which was recently superseded by the `Apollo Platform`.
 
@@ -167,7 +167,7 @@ And we've got many more, for example for the internal `REST` client and also the
 
 There's a lot of heated discussion about monitoring tools in our company at the moment and `Apollo` took the `GraphQL` APM space by storm in the last two years, but we found this way both feasible and practical. If there's a killer feature in `Apollo` that we direly want and aren't able to replicate, then we'd probably have a second look at the `Apollo Platform`, but based on the experience of the last two years, we don't feel like we need to.
 
-# 10. Schema-first is only half of the story
+## 10. Schema-first is only half of the story
 When I saw the first bits of [SDL](https://alligator.io/graphql/graphql-sdl/) I immediately liked the idea. We had the challenge at our company that we operate in a polyglot environment and we specifically didn't want to teach the programming language the `GraphQL` server was written in to everyone who contributing to it. On top of that we were searching for a way to have a meaningful discussion about the schema without going too much into the mechanics of it, a good abstraction so to speak. SDL looked like the perfect fit.
 
 And to a certain degree it is. Almost everyone we worked with, be it backend engineer or frontend-engineer, native or web focused, all of them were able to pick up SDL in very short time. However in all of the available `GraphQL` servers I know, the declarative part ends once you hit the resolvers and you're forced to learn the programming language the server is implemented in again. 
@@ -178,7 +178,7 @@ Too be clear we're pretty happy with our results. With our system, we're able to
 
 > In case you're curious: My co-worker David gave an excellent talk about our SDL approach at last [years GraphQL EU conference](https://www.youtube.com/watch?v=kMOq3nf8vKY).
 
-# Conclusion
+## Conclusion
 This post started out as the summary of what we learned in the first year with `GraphQL`. Somewhere in the first half, it somehow reshaped into overall learnings so far. Things usually overlap a bit time-wise and I thought the post is probably more valuable if I share all of our learnings.
 
 I hope I could give you a bit "food for thought" when it comes to `GraphQL`. Like I said in the introduction, my feeling is that we already have enough success stories out there and need to get a more rounded picture.

--- a/_posts/2019-04-05-the-game-has-changed.md
+++ b/_posts/2019-04-05-the-game-has-changed.md
@@ -32,7 +32,7 @@ Now with the game being so fast, decision making solely happens on the field. Pl
 
 If you ever watched a top squad from the higher ranks of a stadium, you'd also probably realized the magnificent coordination that seems to happen intuitively. Gone are the static positions in the past. You see coordinated changes of the system in offense and defense depending on the game situation. Obviously it's not intuitive, it has been trained to the excess into the squad, but sometimes it looks to easy and natural that it has the feeling of intuitiveness.
 
-# So why am I writing about this?
+## So why am I writing about this?
 
 I find that fascinating and beautiful. When I was looking for inspiration on how I wanted to lead an engineering team, I peeked into all sorts of disciplines and professions. Besides the typical management literature two areas that you often end up at are competitive, squad based sports and the military. And I usually prefer the former. 
 
@@ -110,7 +110,7 @@ I'm personally trying to spend more at least 20-25% of my time per week on opera
 ## Embrace that we're all on a way to somewhere
 Like players in the pitch, there's high demand for really great IT professionals on the market. You can try to fight that, but you can also choose to embrace that. Allow your team to be in the spotlight wherever possible. Give the thing you're working on actual faces that people can relate too. Increase their marked value. Aim for having a good and successful time together. Cherish it, because eventually like all good times in life, things will come to an end. One or more of you are going to leave. That's normal and fine. But the relationships stick and your team culture and spirit might also be preserved even when you're not part of it any more.
 
-# Closing thoughts
+## Closing thoughts
 
 Things have become noticeably faster and ever changing compared to 10 or 20 years ago in our profession. Decide for yourself what this means for knowledge work and collaboration. I gave you a brief overview about the conclusions that I derived from this by looking outside of our profession, namely professional football.
 

--- a/_posts/2026-02-23-on-boilerplate-and-the-death-of-old-principles.md
+++ b/_posts/2026-02-23-on-boilerplate-and-the-death-of-old-principles.md
@@ -1,5 +1,6 @@
 ---
 title: "On Boilerplate and the Death of Old Principles"
+seo_title: "Boilerplate and the Death of Old Principles"
 excerpt: "When a machine can rewrite a module in seconds, do YAGNI and DRY still earn their place? The principles survive — but the reasons we hold them shouldn't."
 ---
 

--- a/_posts/2026-02-24-openclaw-end-of-saas-era-web4.md
+++ b/_posts/2026-02-24-openclaw-end-of-saas-era-web4.md
@@ -1,5 +1,6 @@
 ---
 title: "OpenClaw, the End of the SaaS Playbook, and the Arrival of Web 4.0"
+seo_title: "OpenClaw and the Arrival of Web 4.0"
 excerpt: "OpenAI's OpenClaw hire was framed as a talent acquisition. Zoom out and you see a platform stack being assembled in plain sight — model, agent, app store, distribution, device. The opening move of Web 4.0."
 ---
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -68,7 +68,8 @@ img { max-width: 100%; display: block; }
   gap: 14px;
   align-items: flex-start;
 }
-.masthead h1 {
+.masthead h1,
+.masthead .site-title {
   font-family: var(--serif);
   font-weight: 500;
   font-style: italic;
@@ -77,7 +78,8 @@ img { max-width: 100%; display: block; }
   letter-spacing: -0.02em;
   margin: 0;
 }
-.masthead h1 .roman { font-weight: 600; font-style: normal; }
+.masthead h1 .roman,
+.masthead .site-title .roman { font-weight: 600; font-style: normal; }
 .nav {
   font-family: var(--sans);
   display: flex;
@@ -490,6 +492,7 @@ img { max-width: 100%; display: block; }
 
 /* Clean link styles where titles wrap markup-rendered anchors */
 .masthead h1 a,
+.masthead .site-title a,
 .lead h2 a,
 .post-list .title a,
 .archive-list .title a {


### PR DESCRIPTION
## Summary

Correct the site-wide SEO problems in heading semantics, document metadata, page descriptions, feed discovery, and search-result title length.

## Approach

- Give every generated page exactly one meaningful H1 and demote legacy article sections beneath it.
- Define missing legacy post titles and unique descriptions for the Now and Archive pages.
- Render the existing Google verification, author, social-link, and image configuration as Open Graph, Twitter card, and schema.org JSON-LD metadata.
- Keep one plugin-generated Atom discovery link.
- Use compact document-title suffixes and targeted SEO titles without changing visible article headlines.

Each correction was built, verified, and committed separately.

## How to test

1. Run `bundle exec jekyll build`.
2. Inspect the generated files under `_site/` and confirm each HTML page has one H1, one canonical, one Atom discovery link, and one JSON-LD block.
3. Confirm every page includes Google verification, Open Graph, and Twitter card metadata.
4. Confirm the generated titles are no longer than 60 characters and the Now, Archive, and homepage descriptions are distinct.

The final automated audit validated all of these checks across 21 generated HTML pages.

<details>
<summary>ℹ️ Harness Composer diagnostics</summary>

### Version

Autonex Harness Composer
sdlc_plugin_version: 0.31.1
plugin_git_commit: unknown
repo_harness_bootstrapped: false

Harness Composer doctor reported that this repository is not bootstrapped: `.harness-composer/CONFIG.yaml`, the repo shim, recipe state, and template state are absent. Schema, inventory, synchronization, shim, publication-readiness, and stale-state checks were therefore skipped.

### Session Diagnostics

Autonex Harness Composer diagnostics
agent: codex (source: codex_session)
session_resolved: true (confidence: low)
model: gpt-5.6-sol
model_flags: high
provider: openai
runtime_version: 0.145.0
approval_policy: never
sandbox_policy: danger-full-access
collaboration_mode: default
reason: CODEX_THREAD_ID not set; used latest Codex session candidate

</details>
