### PR TITLE
fix(seo): resolve audit findings — titles, robots, 404, OG/JSON-LD, meta hygiene

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,8 @@
+---
+layout: page
+title: "Page not found"
+permalink: /404.html
+sitemap: false
+---
+<p class="dek">That link points somewhere that doesn&rsquo;t exist &mdash; a moved post, a typo, or a page that never was.</p>
+<p><a href="{{ '/' | relative_url }}">Back to the front page</a> &middot; <a href="{{ '/archive/' | relative_url }}">Browse the archive</a></p>

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.4"
 
 group :jekyll_plugins do
-  gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "jekyll-feed"
   gem "jekyll-include-cache"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-sitemap (1.4.0)
@@ -167,7 +166,6 @@ DEPENDENCIES
   jekyll (~> 4.4)
   jekyll-feed
   jekyll-include-cache
-  jekyll-paginate
   jekyll-sitemap
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -73,13 +73,10 @@ sass:
 
 # Outputting
 permalink: /:title/
-paginate: 20
-paginate_path: /page:num/
 timezone:
 
 # Plugins
 plugins:
-  - jekyll-paginate
   - jekyll-sitemap
   - jekyll-feed
   - jekyll-include-cache

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ baseurl                  :
 google_site_verification : "Ao9ozZz4Tex8Qb6oHnI1UKlsjaJPuY0gBpB-EP_GquY"
 
 # Social Sharing
-og_image                 : "/assets/images/bjoern-portrait.png"
+og_image                 : "/assets/images/bjro.jpg"
 social:
   type                   : Person
   name                   : "Björn Rochel"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,9 @@
 <meta property="og:url" content="{{ seo_url }}" />
 <meta property="og:image" content="{{ seo_image }}" />
 <meta property="og:image:alt" content="{{ page.image_alt | default: site.author.name | escape }}" />
-{% if page.date %}<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />{% endif %}
+{% if page.date %}<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+<meta property="article:modified_time" content="{{ page.last_modified_at | default: page.date | date_to_xmlschema }}" />
+<meta property="article:author" content="{{ site.author.name | escape }}" />{% endif %}
 <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}" />
 <meta name="twitter:title" content="{{ seo_title | escape }}" />
 <meta name="twitter:description" content="{{ seo_description | escape }}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,6 +36,10 @@
   "description": {{ seo_description | jsonify }},
   "url": {{ seo_url | jsonify }},
   "image": {{ seo_image | jsonify }},
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": {{ seo_url | jsonify }}
+  },
   {% if page.date %}
   "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
   "dateModified": {{ page.last_modified_at | default: page.date | date_to_xmlschema | jsonify }},
@@ -45,6 +49,11 @@
     "name": {{ site.author.name | jsonify }},
     "url": {{ site.url | jsonify }},
     "sameAs": {{ site.social.links | jsonify }}
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": {{ site.author.name | jsonify }},
+    "url": {{ site.url | jsonify }}
   }
 }
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
 <meta property="og:image" content="{{ seo_image }}" />
 <meta property="og:image:alt" content="{{ page.image_alt | default: site.author.name | escape }}" />
 {% if page.date %}<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />{% endif %}
-<meta name="twitter:card" content="summary" />
+<meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}" />
 <meta name="twitter:title" content="{{ seo_title | escape }}" />
 <meta name="twitter:description" content="{{ seo_description | escape }}" />
 <meta name="twitter:image" content="{{ seo_image }}" />

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -23,7 +23,7 @@ nav_section: archive
     {% assign now_year = 'now' | date: '%Y' | plus: 0 %}
     {% assign span = now_year | minus: first_year | plus: 1 %}
     <div class="archive-stats">{{ total }} Dispatches · {{ span }} Years · ≈{{ hours }} hrs of reading</div>
-    <h1>{{ page.title | default: "The Archive — every dispatch since 2014." }}</h1>
+    <h1>{{ page.title | default: "The Archive — every dispatch since 2018." }}</h1>
 
     {% for yr in by_year %}
     <section class="year-section" id="y-{{ yr.name }}">

--- a/_pages/archive.html
+++ b/_pages/archive.html
@@ -1,6 +1,7 @@
 ---
 layout: archive
-title: "The Archive — every dispatch since 2014."
+title: "The Archive — every dispatch since 2018."
+seo_title: "Archive"
 excerpt: "Browse Björn Rochel's writing on agentic engineering, software architecture, GraphQL, and engineering leadership."
 permalink: /archive/
 nav_section: archive

--- a/_posts/2018-11-23-on-agile-codebases.md
+++ b/_posts/2018-11-23-on-agile-codebases.md
@@ -1,4 +1,5 @@
 ---
+title: "On Agile Codebases"
 excerpt: "Agility isn't a process. It's the technical decisions you made six months ago. The XING One codebase choices that kept us able to actually inspect and adapt."
 ---
 I've participated in efforts to deliver software for more than 15 years now. The first five using the good old waterfall approach with infrequent, big releases; the last 10 years in teams that followed one of the flavors of the agile method. 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+---
+sitemap: false
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ '/sitemap.xml' | absolute_url }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
     "name": "bjro-blog",
     "compatibility_date": "2026-05-14",
     "assets": {
-      "directory": "./_site"
+      "directory": "./_site",
+      "not_found_handling": "404-page"
     }
   }


### PR DESCRIPTION
Fixes the actionable issues from the SEO audit of the site. Each fix is a separate commit and was verified against the built `_site/` output.

## Critical
1. **Missing post title** — `2018-11-23-on-agile-codebases.md` had no `title:`, producing an empty `<h1>` and a generic `<title>`/`og:title`. Added `"On Agile Codebases"`. URL unchanged (permalink `:title` derives from the filename slug, not front matter).
2. **No robots.txt** — the `jekyll-sitemap` output was unadvertised. Added `robots.txt` emitting an absolute `Sitemap:` line; excluded from the sitemap itself.
3. **No 404 page** — added a styled `404.html` using the site layout, and set Cloudflare `not_found_handling: "404-page"` in `wrangler.jsonc` so it is actually served.

## Medium
4. **og:image + twitter card** — default `og_image` was a 180×180 portrait (below social minimums); switched to the 800×800 `bjro.jpg`. `twitter:card` was hardcoded `summary`; now `summary_large_image` when a post sets `image:`.
5. **JSON-LD** — `BlogPosting` now includes `mainEntityOfPage` and `publisher`.
6. **article:modified_time** — head emitted `article:published_time` only; added `article:modified_time` (mirrors the JSON-LD `dateModified` fallback) and `article:author`.
7. **Dead pagination** — removed the unused `jekyll-paginate` plugin and its `paginate`/`paginate_path` config (nothing referenced `paginator`; the home list uses `site.posts`, the archive lists all by year).

## Minor
8. **Archive title** — front-matter title collided with the appended author name (double em-dash + trailing period) and claimed "since 2014" while the oldest post and dynamic stats are 2018. Added a clean `seo_title: "Archive"` for the `<title>` tag and corrected the year; the editorial on-page `<h1>` is preserved.

## Verification
Full build is clean (no errors/warnings). All 22 built pages have non-empty `<title>`, `<h1>`, and a canonical link; `robots.txt`, `404.html`, `sitemap.xml`, and `feed.xml` are all present.

## Out of scope (noted, not changed)
- **Per-post hero og:images** — the template now supports `image:` front matter, but choosing a representative image per post is editorial and left to the author.
- **Dual-hosting (bjro.de vs github.io)** — mitigated by existing canonical tags; a redirect is a deployment decision.
- **Stale `CLAUDE.md`** — mentions Minimal Mistakes / GitHub Pages (actual: custom theme on Cloudflare); docs-only, excluded from the build, no SEO impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)